### PR TITLE
Added Hour and Minute functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,8 +171,8 @@
 		</div>
 		
 		<script>
-			//enter the count down date using the format year/month/day
-			$(".ccounter").ccountdown(2014,12,25);
+			//enter the count down date using the format year, month, day, time:time
+			$(".ccounter").ccountdown(2014,12,25,'18:00');
 		</script>
     
 		

--- a/jquery.ccountdown.js
+++ b/jquery.ccountdown.js
@@ -9,34 +9,37 @@
  *
  * Thanks to http://www.javascriptkit.com/
  */
-(function($){
-	$.fn.ccountdown = function(_yr,_m,_d){
-		var _montharray=new Array("Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec")
-		_changeTime(); // calling function first time so that it wll setup remaining time
-		function _changeTime() {
-			var _today=new Date();
-			var _todayy=_today.getYear();
-			if (_todayy < 1000)
-			_todayy+=1900;
-			var _todaym=_today.getMonth();
-			var _todayd=_today.getDate();
-			var _todayh=_today.getHours();
-			var _todaymin=_today.getMinutes();
-			var _todaysec=_today.getSeconds();
-			var _todaystring=_montharray[_todaym]+" "+_todayd+", "+_todayy+" "+_todayh+":"+_todaymin+":"+_todaysec;
-			_futurestring=_montharray[_m-1]+" "+_d+", "+_yr;
-			/* calculation of remaining days, hrs, min, and secs */
-			_dd=Date.parse(_futurestring)-Date.parse(_todaystring);
-			_dday=Math.floor(_dd/(60*60*1000*24)*1);
-			_dhour=Math.floor((_dd%(60*60*1000*24))/(60*60*1000)*1);
-			_dmin=Math.floor(((_dd%(60*60*1000*24))%(60*60*1000))/(60*1000)*1);
-			_dsec=Math.floor((((_dd%(60*60*1000*24))%(60*60*1000))%(60*1000))/1000*1);
-			var $ss = $(".second"), $mm = $(".minute"),$hh = $(".hour"),$dd = $(".days");
-			$ss.val(_dsec).trigger("change");
-			$mm.val(_dmin).trigger("change");
-			$hh.val(_dhour).trigger("change");
-			$dd.val(_dday).trigger("change");
-		}
-		setInterval(_changeTime ,1000);
-	};
-})(jQuery);
+ (function($){
+ 	$.fn.ccountdown = function(_yr,_m,_d,_t){
+ 		var _montharray=new Array("Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec")
+ 		var _today=new Date();
+ 		_changeTime(); // calling function first time so that it wll setup remaining time
+ 		function _changeTime() {
+ 			var _today=new Date();
+ 			var _todayy=_today.getYear();
+ 			if (_todayy < 1000)
+ 			_todayy+=1900;
+ 			var _todaym=_today.getMonth();
+ 			var _todayd=_today.getDate();
+ 			var _todayh=_today.getHours();
+ 			var _todaymin=_today.getMinutes();
+ 			var _todaysec= _today.getSeconds();
+            _todaysec= "0" + _todaysec;
+            _todaysec = _todaysec.substr(_todaysec.length - 2);
+ 			var _todaystring=_montharray[_todaym]+" "+_todayd+", "+_todayy+" "+_todayh+":"+_todaymin+":"+_todaysec;
+ 			_futurestring=_montharray[_m-1]+" "+_d+", "+_yr+" "+_t;
+ 			/* calculation of remaining days, hrs, min, and secs */
+ 			_dd=Date.parse(_futurestring)-Date.parse(_todaystring);
+ 			_dday=Math.floor(_dd/(60*60*1000*24)*1);
+ 			_dhour=Math.floor((_dd%(60*60*1000*24))/(60*60*1000)*1);
+ 			_dmin=Math.floor(((_dd%(60*60*1000*24))%(60*60*1000))/(60*1000)*1);
+ 			_dsec=Math.floor((((_dd%(60*60*60*1000*24))%(60*60*1000))%(60*1000))/1000*1);
+ 			var $ss = $(".second"), $mm = $(".minute"),$hh = $(".hour"),$dd = $(".days");
+ 			$ss.val(_dsec).trigger("change");
+ 			$mm.val(_dmin).trigger("change");
+ 			$hh.val(_dhour).trigger("change");
+ 			$dd.val(_dday).trigger("change");
+ 		}
+ 		setInterval(_changeTime ,1000);
+ 	};
+ })(jQuery);

--- a/js/jquery.ccountdown.js
+++ b/js/jquery.ccountdown.js
@@ -9,34 +9,37 @@
  *
  * Thanks to http://www.javascriptkit.com/
  */
-(function($){
-	$.fn.ccountdown = function(_yr,_m,_d){
-		var _montharray=new Array("Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec")
-		_changeTime(); // calling function first time so that it wll setup remaining time
-		function _changeTime() {
-			var _today=new Date();
-			var _todayy=_today.getYear();
-			if (_todayy < 1000)
-			_todayy+=1900;
-			var _todaym=_today.getMonth();
-			var _todayd=_today.getDate();
-			var _todayh=_today.getHours();
-			var _todaymin=_today.getMinutes();
-			var _todaysec=_today.getSeconds();
-			var _todaystring=_montharray[_todaym]+" "+_todayd+", "+_todayy+" "+_todayh+":"+_todaymin+":"+_todaysec;
-			_futurestring=_montharray[_m-1]+" "+_d+", "+_yr;
-			/* calculation of remaining days, hrs, min, and secs */
-			_dd=Date.parse(_futurestring)-Date.parse(_todaystring);
-			_dday=Math.floor(_dd/(60*60*1000*24)*1);
-			_dhour=Math.floor((_dd%(60*60*1000*24))/(60*60*1000)*1);
-			_dmin=Math.floor(((_dd%(60*60*1000*24))%(60*60*1000))/(60*1000)*1);
-			_dsec=Math.floor((((_dd%(60*60*1000*24))%(60*60*1000))%(60*1000))/1000*1);
-			var $ss = $(".second"), $mm = $(".minute"),$hh = $(".hour"),$dd = $(".days");
-			$ss.val(_dsec).trigger("change");
-			$mm.val(_dmin).trigger("change");
-			$hh.val(_dhour).trigger("change");
-			$dd.val(_dday).trigger("change");
-		}
-		setInterval(_changeTime ,1000);
-	};
-})(jQuery);
+ (function($){
+ 	$.fn.ccountdown = function(_yr,_m,_d,_t){
+ 		var _montharray=new Array("Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec")
+ 		var _today=new Date();
+ 		_changeTime(); // calling function first time so that it wll setup remaining time
+ 		function _changeTime() {
+ 			var _today=new Date();
+ 			var _todayy=_today.getYear();
+ 			if (_todayy < 1000)
+ 			_todayy+=1900;
+ 			var _todaym=_today.getMonth();
+ 			var _todayd=_today.getDate();
+ 			var _todayh=_today.getHours();
+ 			var _todaymin=_today.getMinutes();
+ 			var _todaysec= _today.getSeconds();
+            _todaysec= "0" + _todaysec;
+            _todaysec = _todaysec.substr(_todaysec.length - 2);
+ 			var _todaystring=_montharray[_todaym]+" "+_todayd+", "+_todayy+" "+_todayh+":"+_todaymin+":"+_todaysec;
+ 			_futurestring=_montharray[_m-1]+" "+_d+", "+_yr+" "+_t;
+ 			/* calculation of remaining days, hrs, min, and secs */
+ 			_dd=Date.parse(_futurestring)-Date.parse(_todaystring);
+ 			_dday=Math.floor(_dd/(60*60*1000*24)*1);
+ 			_dhour=Math.floor((_dd%(60*60*1000*24))/(60*60*1000)*1);
+ 			_dmin=Math.floor(((_dd%(60*60*1000*24))%(60*60*1000))/(60*1000)*1);
+ 			_dsec=Math.floor((((_dd%(60*60*60*1000*24))%(60*60*1000))%(60*1000))/1000*1);
+ 			var $ss = $(".second"), $mm = $(".minute"),$hh = $(".hour"),$dd = $(".days");
+ 			$ss.val(_dsec).trigger("change");
+ 			$mm.val(_dmin).trigger("change");
+ 			$hh.val(_dhour).trigger("change");
+ 			$dd.val(_dday).trigger("change");
+ 		}
+ 		setInterval(_changeTime ,1000);
+ 	};
+ })(jQuery);


### PR DESCRIPTION
Adding a third string to the .ccountdown array now allows for hours and minutes to be calculated.

A little bit of extra JS was required to compare the seconds correctly — Because our new time variable uses two numbers rather than one, there is a 10 second period (when the current time is between 1 and 9 seconds) it requires an additional leading 0.

Other than that, the new _t variable is just added to the _futurestring.
